### PR TITLE
Remove footnote from title

### DIFF
--- a/paper/header.tex
+++ b/paper/header.tex
@@ -1,6 +1,6 @@
 % **************GENERATED FILE, DO NOT EDIT**************
 
-\title{LazySets.jl: Scalable Symbolic-Numeric Set Computations$^*$}
+\title{LazySets.jl: Scalable Symbolic-Numeric Set Computations}
 
 \author[1]{Marcelo Forets}
 \author[2]{Christian Schilling}
@@ -10,7 +10,7 @@
 \keywords{Set propagation, Geometry, Reachability analysis, Hybrid system, Support function, Formal verification}
 
 \hypersetup{
-pdftitle = {LazySets.jl: Scalable Symbolic-Numeric Set Computations$^*$},
+pdftitle = {LazySets.jl: Scalable Symbolic-Numeric Set Computations},
 pdfsubject = {JuliaCon 2019 Proceedings},
 pdfauthor = {Marcelo Forets, Christian Schilling},
 pdfkeywords = {Set propagation, Geometry, Reachability analysis, Hybrid system, Support function, Formal verification},

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -26,7 +26,7 @@
 \end{abstract}
 
 \renewcommand{\thefootnote}{\fnsymbol{footnote}}
-\footnotetext[1]{Both authors contributed equally.}
+\footnotetext[0]{Both authors contributed equally.}
 \renewcommand{\thefootnote}{\arabic{footnote}}
 
 \section{Introduction}

--- a/paper/paper.yml
+++ b/paper/paper.yml
@@ -1,4 +1,4 @@
-title: "LazySets.jl: Scalable Symbolic-Numeric Set Computations$^*$"
+title: "LazySets.jl: Scalable Symbolic-Numeric Set Computations"
 keywords:
   - Set propagation
   - Geometry


### PR DESCRIPTION
It felt strange to put the footnote in the main text, so I suggest we just have no footnote symbol. See the output below.

---

![Screenshot_20220128_101118](https://user-images.githubusercontent.com/9656686/151520542-efe390bf-1f9b-457f-be33-b5f2afdd5782.png)
